### PR TITLE
feat: Add automatic string length validation to generated models

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The `errorMessageTemplate` supports the following placeholders:
 - `{fieldName}` - The name of the field
 - `{minBound}` - The minimum length (always 0)
 - `{maxBound}` - The maximum length from the database column definition
-- `{dataType}` - sequalize datType
+- `{dataType}` - sequelize dataType
 
 ## ES6
 
@@ -460,6 +460,7 @@ auto.run();
 1. `bigint` columns are treated as strings.
 2. `citext` columns are treated as strings.
 3. New option `--schemas`/`-S` - support for multiple schemas.
+4. Add `validationRules` - see [Validations](#validations) section for details.
 
 ## Testing
 

--- a/src/auto-generator.ts
+++ b/src/auto-generator.ts
@@ -266,7 +266,7 @@ export class AutoGenerator {
 
     let wroteAutoIncrement = false;
     const space = this.space;
-    
+
     // Capture the Sequelize type for validation purposes
     let sqType: string | null = null;
 
@@ -449,7 +449,7 @@ export class AutoGenerator {
               maxBound: bounds.max,
               dataType: sqType,
             });
-            
+
             str += space[3] + "validate: {\n";
             str += space[4] + "len: {\n";
             str += space[5] + `args: [${bounds.min}, ${bounds.max}],\n`;
@@ -460,7 +460,7 @@ export class AutoGenerator {
         }
     }
 
-    
+
 
     // removes the last `,` within the attribute options
     str = str.trim().replace(/,+$/, '') + "\n";
@@ -613,7 +613,7 @@ export class AutoGenerator {
     if (!sqType) {
       return false;
     }
-    
+
     // Check if the Sequelize type is a string type
     // Valid string types: STRING, STRING(n), TEXT, TEXT(tiny|medium|long), CHAR, CHAR(n)
     if (
@@ -636,28 +636,28 @@ export class AutoGenerator {
     if (!sqType) {
       return null;
     }
-    
+
     // Use dialect-specific implementation if available
     if (this.dialect.getStringBounds) {
       return this.dialect.getStringBounds(sqType);
     }
-    
+
     // Default fallback implementation
     const sizeMatch = sqType.match(/\((\d+)\)/);
     const size = sizeMatch ? parseInt(sizeMatch[1], 10) : null;
-    
+
     if (sqType.startsWith('DataTypes.STRING')) {
       return { min: 0, max: size ?? 255 };
     }
-    
+
     if (sqType.startsWith('DataTypes.CHAR')) {
       return { min: 0, max: size ?? 255 };
     }
-    
+
     if (sqType.startsWith('DataTypes.TEXT')) {
       return { min: 0, max: null }; // TEXT is generally unbounded
     }
-    
+
     return null;
   }
 

--- a/src/dialects/dialect-options.ts
+++ b/src/dialects/dialect-options.ts
@@ -1,5 +1,13 @@
 import { Utils } from "sequelize";
 
+/**
+ * Represents the min/max length bounds for string validation.
+ * null values indicate unbounded (no limit).
+ */
+export interface StringBounds {
+  min: number;
+  max: number | null;
+}
 
 export interface DialectOptions {
   name: string;
@@ -18,6 +26,11 @@ export interface DialectOptions {
   showGeographyTypeQuery?: (tableName: string, schemaName?: string) => string;
   showGeometryTypeQuery?: (tableName: string, schemaName?: string) => string;
   showPrecisionQuery?: (tableName: string, schemaName?: string) => string;
+  /**
+   * Returns the string length bounds for a given Sequelize type (e.g. 'DataTypes.STRING(100)').
+   * Based on the database-specific limitations for string types.
+   */
+  getStringBounds?: (sqType: string) => StringBounds | null;
 }
 
 export interface FKRow {

--- a/src/dialects/mssql.ts
+++ b/src/dialects/mssql.ts
@@ -139,30 +139,30 @@ export const mssqlOptions: DialectOptions = {
    * - TEXT: deprecated, up to 2^31-1 characters
    * - CHAR(n): 0 to n characters (max 8,000)
    * - NCHAR(n): 0 to n characters (max 4,000)
-   * 
+   *
    * @param sqType Sequelize DataType string
    * @returns StringBounds or null if not a string type
    */
   getStringBounds: (sqType: string): StringBounds | null => {
     if (!sqType) return null;
-    
+
     // Extract size from type like 100 from DataTypes.STRING(100)
     const sizeMatch = sqType.match(/\((\d+)\)/);
     const size = sizeMatch ? parseInt(sizeMatch[1], 10) : null;
-    
+
     if (sqType.startsWith('DataTypes.STRING')) {
       return { min: 0, max: size ?? 255 };
     }
-    
+
     if (sqType.startsWith('DataTypes.CHAR')) {
       return { min: 0, max: size ?? 255 };
     }
-    
+
     if (sqType.startsWith('DataTypes.TEXT')) {
       // TEXT maps to NVARCHAR(MAX) which is 2^31-1 characters, effectively unbounded
       return { min: 0, max: null };
     }
-    
+
     return null;
   }
 

--- a/src/dialects/mysql.ts
+++ b/src/dialects/mysql.ts
@@ -104,46 +104,46 @@ export const mysqlOptions: DialectOptions = {
    * - MEDIUMTEXT: 16,777,215 bytes
    * - LONGTEXT: 4,294,967,295 bytes
    * - CHAR(n): 0 to n characters (max 255)
-   * 
+   *
    * @param sqType Sequelize DataType string
    * @returns StringBounds or null if not a string type
    */
   getStringBounds: (sqType: string): StringBounds | null => {
     if (!sqType) return null;
-    
+
     // Extract size from type like 100 from DataTypes.STRING(100)
     const sizeMatch = sqType.match(/\((\d+)\)/);
     const size = sizeMatch ? parseInt(sizeMatch[1], 10) : null;
-    
+
     if (sqType.startsWith('DataTypes.STRING')) {
       return { min: 0, max: size ?? 255 };
     }
-    
+
     if (sqType.startsWith('DataTypes.CHAR')) {
       return { min: 0, max: size ?? 255 };
     }
-    
+
     // DataTypes.TEXT without size modifier
     if (sqType === 'DataTypes.TEXT') {
       // Default TEXT in MySQL: 65,535 bytes (~16,383 utf8mb4 chars)
       return { min: 0, max: 65535 };
     }
-    
+
     // TEXT('tiny') -> TINYTEXT: 255 bytes
     if (sqType.includes("'tiny'") || sqType.includes('"tiny"')) {
       return { min: 0, max: 255 };
     }
-    
+
     // TEXT('medium') -> MEDIUMTEXT: 16,777,215 bytes
     if (sqType.includes("'medium'") || sqType.includes('"medium"')) {
       return { min: 0, max: 16777215 };
     }
-    
+
     // TEXT('long') -> LONGTEXT: 4,294,967,295 bytes
     if (sqType.includes("'long'") || sqType.includes('"long"')) {
       return { min: 0, max: 4294967295 };
     }
-    
+
     return null;
   }
 

--- a/src/dialects/postgres.ts
+++ b/src/dialects/postgres.ts
@@ -148,30 +148,30 @@ export const postgresOptions: DialectOptions = {
    * - VARCHAR(n): 0 to n characters (max n is 10,485,760)
    * - TEXT: unlimited (up to 1GB)
    * - CHAR(n): 0 to n characters
-   * 
+   *
    * @param sqType Sequelize DataType string
    * @returns StringBounds or null if not a string type
    */
   getStringBounds: (sqType: string): StringBounds | null => {
     if (!sqType) return null;
-    
+
     // Extract size from type like 100 from DataTypes.STRING(100)
     const sizeMatch = sqType.match(/\((\d+)\)/);
     const size = sizeMatch ? parseInt(sizeMatch[1], 10) : null;
-    
+
     if (sqType.startsWith('DataTypes.STRING')) {
       return { min: 0, max: size ?? 255 };
     }
-    
+
     if (sqType.startsWith('DataTypes.CHAR')) {
       return { min: 0, max: size ?? 255 };
     }
-    
+
     if (sqType.startsWith('DataTypes.TEXT')) {
       // PostgreSQL TEXT has no practical limit (up to 1GB)
       return { min: 0, max: null };
     }
-    
+
     return null;
   }
 

--- a/src/dialects/sqlite.ts
+++ b/src/dialects/sqlite.ts
@@ -85,35 +85,35 @@ export const sqliteOptions: DialectOptions = {
    * - All string types (VARCHAR, TEXT, CHAR) are stored as TEXT
    * - Maximum length is SQLITE_MAX_LENGTH (default 1,000,000,000 bytes)
    * - SQLite doesn't enforce VARCHAR(n) or CHAR(n) limits
-   * 
+   *
    * Note: SQLite is dynamically typed and stores all text as TEXT.
    * The size in VARCHAR(n) is not enforced by SQLite itself.
-   * 
+   *
    * @param sqType Sequelize DataType string
    * @returns StringBounds or null if not a string type
    */
   getStringBounds: (sqType: string): StringBounds | null => {
     if (!sqType) return null;
-    
+
     // Extract size from type like 100 DataTypes.STRING(100)
     // SQLite doesn't enforce these limits, but we return them for application-level validation
     const sizeMatch = sqType.match(/\((\d+)\)/);
     const size = sizeMatch ? parseInt(sizeMatch[1], 10) : null;
-    
+
     if (sqType.startsWith('DataTypes.STRING')) {
       // SQLite doesn't enforce limits, but we use the specified size for validation
       // If no size specified, SQLite has no limit (effectively unbounded)
       return { min: 0, max: size ?? null };
     }
-    
+
     if (sqType.startsWith('DataTypes.CHAR')) {
       return { min: 0, max: size ?? null };
     }
-    
+
     if (sqType.startsWith('DataTypes.TEXT')) {
       return { min: 0, max: null };
     }
-    
+
     return null;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,6 +200,40 @@ export interface AutoOptions {
   pkSuffixes?: string[];
   /** Use `sequelize.define` instead of `init` for model initialization.  See issues #527, #559, #573 */
   useDefine: boolean;
+  /** Validation rules */
+  validationRules?: ValidationRule[];
+}
+
+export interface ValidationRule {
+  /** Types of validation that can be added and checked */
+  type: 'stringLengthCheck',
+  /** Error message template (with placeholders) for specific validation
+   * Any of provided placeholders will be substituted by code-generator.
+   * You can setting up it's amount by itself by setting up custom template message
+   * 
+   * @example
+   * - 'stringLengthCheck': 'Field {tableName}.{fieldName} may not exceed {maxBound} characters. Original DataType: {dataType}.' 
+   */
+  errorMessageTemplate: string,
+};
+
+/**
+ * Formats a string template by replacing placeholders with provided values.
+ * Similar to .NET's string.Format method.
+ * 
+ * @param template The string template with placeholders in {key} format
+ * @param params Object containing key-value pairs for substitution
+ * @returns The formatted string with placeholders replaced
+ * 
+ * @example
+ * formatString('{fieldName} max is {maxBound}', { fieldName: 'username', maxBound: 100 })
+ * // Returns: 'username max is 100'
+ */
+export function formatString(template: string, params: Record<string, string | number | null>): string {
+  return template.replace(/\{(\w+)\}/g, (match, key) => {
+    const value = params[key];
+    return value !== undefined && value !== null ? String(value) : match;
+  });
 }
 
 export type TSField = { special: string[]; elementType: string; } & ColumnDescription;

--- a/test/string-validation.test.js
+++ b/test/string-validation.test.js
@@ -1,0 +1,245 @@
+const { expect } = require('chai');
+const { describe, it } = require('mocha');
+const { AutoGenerator } = require('../lib/auto-generator');
+const { TableData } = require('../lib/types');
+
+// Mock dialect options for testing
+const mockDialectOptions = {
+  name: 'postgres',
+  hasSchema: true,
+  getForeignKeysQuery: () => '',
+  countTriggerQuery: () => '',
+  isPrimaryKey: () => false,
+  isSerialKey: () => false,
+  showViewsQuery: () => '',
+  getStringBounds: (sqType) => {
+    if (!sqType) return null;
+    
+    const sizeMatch = sqType.match(/\((\d+)\)/);
+    const size = sizeMatch ? parseInt(sizeMatch[1], 10) : null;
+    
+    if (sqType.startsWith('DataTypes.STRING')) {
+      return { min: 0, max: size ?? 255 };
+    }
+    if (sqType.startsWith('DataTypes.CHAR')) {
+      return { min: 0, max: size ?? 255 };
+    }
+    if (sqType.startsWith('DataTypes.TEXT')) {
+      return { min: 0, max: null }; // Unbounded
+    }
+    return null;
+  }
+};
+
+function createMockTableData(fields) {
+  const tableData = new TableData();
+  tableData.tables = {
+    'test_table': fields
+  };
+  tableData.foreignKeys = { 'test_table': {} };
+  tableData.hasTriggerTables = {};
+  tableData.indexes = {};
+  tableData.relations = [];
+  return tableData;
+}
+
+function createOptions(overrides = {}) {
+  return {
+    spaces: true,
+    indentation: 2,
+    lang: 'es5',
+    singularize: false,
+    useDefine: false,
+    directory: './models',
+    additional: {},
+    ...overrides
+  };
+}
+
+describe('sequelize-auto string validation', function() {
+  
+  describe('AutoGenerator with string validation disabled', function() {
+    it('should NOT generate validation when validationRules is not set', function() {
+      const tableData = createMockTableData({
+        username: {
+          type: 'VARCHAR(100)',
+          allowNull: false,
+          primaryKey: false
+        }
+      });
+      
+      const options = createOptions();
+      const generator = new AutoGenerator(tableData, mockDialectOptions, options);
+      const result = generator.generateText();
+      
+      expect(result['test_table']).to.not.include('validate:');
+      expect(result['test_table']).to.not.include('len:');
+    });
+
+    it('should NOT generate validation when createValidationMessageOnStringDataTypeOverFlow is false', function() {
+      const tableData = createMockTableData({
+        username: {
+          type: 'VARCHAR(100)',
+          allowNull: false,
+          primaryKey: false
+        }
+      });
+      
+      const options = createOptions({
+        validationRules: []
+      });
+      
+      const generator = new AutoGenerator(tableData, mockDialectOptions, options);
+      const result = generator.generateText();
+      
+      expect(result['test_table']).to.not.include('validate:');
+      expect(result['test_table']).to.not.include('len:');
+    });
+  });
+
+  describe('AutoGenerator with string validation enabled', function() {
+    it('should generate validation with default message when enabled', function() {
+      const tableData = createMockTableData({
+        username: {
+          type: 'VARCHAR(100)',
+          allowNull: false,
+          primaryKey: false
+        }
+      });
+      
+      const options = createOptions({
+        validationRules: [
+          {
+            type: 'stringLengthCheck',
+          }
+        ]
+      });
+      
+      const generator = new AutoGenerator(tableData, mockDialectOptions, options);
+      const result = generator.generateText();
+      
+      expect(result['test_table']).to.include('validate:');
+      expect(result['test_table']).to.include('len:');
+      expect(result['test_table']).to.include('args: [0, 100]');
+      expect(result['test_table']).to.include('Field test_table.username may not exceed 100 characters. Original DataType: DataTypes.STRING(100).');
+    });
+
+    it('should generate validation with custom message template', function() {
+      const tableData = createMockTableData({
+        email: {
+          type: 'VARCHAR(255)',
+          allowNull: true,
+          primaryKey: false
+        }
+      });
+      
+      const options = createOptions({
+        validationRules: [
+          {
+            type: 'stringLengthCheck',
+            errorMessageTemplate: 'Field "{fieldName}" must be between {minBound} and {maxBound} characters', 
+          }
+        ],
+      });
+      
+      const generator = new AutoGenerator(tableData, mockDialectOptions, options);
+      const result = generator.generateText();
+      
+      expect(result['test_table']).to.include('validate:');
+      expect(result['test_table']).to.include('len:');
+      expect(result['test_table']).to.include('args: [0, 255]');
+      expect(result['test_table']).to.include('Field "email" must be between 0 and 255 characters');
+    });
+
+    it('should NOT generate validation for TEXT type (unbounded)', function() {
+      const tableData = createMockTableData({
+        description: {
+          type: 'TEXT',
+          allowNull: true,
+          primaryKey: false
+        }
+      });
+      
+      const options = createOptions({
+        validationRules: [
+          {
+            type: 'stringLengthCheck',
+          }
+        ]
+      });
+      
+      const generator = new AutoGenerator(tableData, mockDialectOptions, options);
+      const result = generator.generateText();
+      
+      // TEXT has null max bound, so validation should not be generated
+      expect(result['test_table']).to.not.include('validate:');
+      expect(result['test_table']).to.not.include('len:');
+    });
+
+    it('should generate validation for multiple string fields', function() {
+      const tableData = createMockTableData({
+        firstName: {
+          type: 'VARCHAR(50)',
+          allowNull: false,
+          primaryKey: false
+        },
+        lastName: {
+          type: 'VARCHAR(50)',
+          allowNull: false,
+          primaryKey: false
+        },
+        age: {
+          type: 'INTEGER',
+          allowNull: true,
+          primaryKey: false
+        }
+      });
+      
+      const options = createOptions({
+        validationRules: [
+          {
+            type: 'stringLengthCheck',
+          }
+        ]
+      });
+      
+      const generator = new AutoGenerator(tableData, mockDialectOptions, options);
+      const result = generator.generateText();
+      
+      // Should have validation for firstName and lastName
+      expect(result['test_table']).to.include('Field test_table.firstName may not exceed 50 characters. Original DataType: DataTypes.STRING(50).');
+      expect(result['test_table']).to.include('Field test_table.lastName may not exceed 50 characters. Original DataType: DataTypes.STRING(50).');
+      
+      // age is INTEGER, should not have string validation
+      const ageSection = result['test_table'].split('age:')[1];
+      if (ageSection) {
+        const ageBlock = ageSection.split('},')[0];
+        expect(ageBlock).to.not.include('validate:');
+      }
+    });
+
+    it('should generate validation for CHAR type', function() {
+      const tableData = createMockTableData({
+        countryCode: {
+          type: 'CHAR(2)',
+          allowNull: false,
+          primaryKey: false
+        }
+      });
+      
+      const options = createOptions({
+        validationRules: [
+          {
+            type: 'stringLengthCheck',
+          }
+        ]
+      });
+      
+      const generator = new AutoGenerator(tableData, mockDialectOptions, options);
+      const result = generator.generateText();
+      
+      expect(result['test_table']).to.include('validate:');
+      expect(result['test_table']).to.include('args: [0, 2]');
+    });
+  });
+});


### PR DESCRIPTION
feat: Add extensible validation system with string length validation

Add configurable validation rules to Sequelize models generated by sequelize-auto.
Currently supports string length validation, providing user-friendly validation errors before database upsert operations fail with overflow error.

- Add ValidationRule interface with type-based validation system
- Implement validationRules as an array to support multiple validation types
- Add 'stringLengthCheck' validation type for string sequalize fields
- Implement getStringBounds() in all dialect options (MySQL, MSSQL, PostgreSQL, SQLite) with database-specific limits
- Generate validate.len constraints when stringLengthCheck is enabled
- Support customizable error message templates (for 'stringLengthCheck' validation rule) with placeholders ({fieldName}, {minBound}, {maxBound}, {datatype}, {tableName})
- Add formatString() utility for template string substitution

When stringLengthCheck validation is enabled, converts unfriendly DB errors like "value too long for type character varying(255)" into user-friendly messages like "Field lastName may not exceed 50 characters".

The validation system is designed to be extensible - new validation types can be added to the validationRules array in the future.

Fixes issues with unclear string overflow errors in database operations.